### PR TITLE
Bug Fix: When no image was selected, app crashes upon calling Gemini …

### DIFF
--- a/app/src/main/java/com/example/tutorai/MainActivity.java
+++ b/app/src/main/java/com/example/tutorai/MainActivity.java
@@ -91,6 +91,10 @@ public class MainActivity extends AppCompatActivity {
                 /* apiKey */ "AIzaSyBx6F6-qxtaTgFJ5g_uE-UzocLo3KIgpjI");
         GenerativeModelFutures model = GenerativeModelFutures.from(gm);
 
+        if (selectedImageBitmap == null){
+            selectedImageBitmap = BitmapFactory.decodeResource(getResources(), R.drawable.pixel);
+        }
+
         Content content = new Content.Builder()
                 .addText(editTextValue)
                 .addImage(selectedImageBitmap)


### PR DESCRIPTION
Bug Fix: When no image was selected, app crashes upon calling Gemini API because of failure to intialize bitmap, which was done before onClick.

Doing quick patch for bug.